### PR TITLE
Hide Id + hybrid directed graphs

### DIFF
--- a/config.js
+++ b/config.js
@@ -52,6 +52,11 @@ setParams({
             Show the id of the node in the list
             this setting can't be changed from the User Interface
         */
+    showEdgeArrow : true,
+        /*
+            Show the edge arrows when the edge is directed
+            this setting can't be changed from the User Interface
+        */
     language: false,
         /*
             Set to an ISO language code to switch the interface to that language.

--- a/config.js
+++ b/config.js
@@ -47,6 +47,11 @@ setParams({
             this setting can't be changed from the User Interface
         */
     showEdgeLabel : true,
+    showId : true,
+        /*
+            Show the id of the node in the list
+            this setting can't be changed from the User Interface
+        */
     language: false,
         /*
             Set to an ISO language code to switch the interface to that language.

--- a/js/gexfjs.js
+++ b/js/gexfjs.js
@@ -224,23 +224,41 @@ function displayNode(_nodeIndex, _recentre) {
         for (var i in _d.attributes) {
             _str += '<li><b>' + strLang(i) + '</b> : ' + replaceURLWithHyperlinks( _d.attributes[i] ) + '</li>';
         }
-        _str += '</ul><h4>' + ( GexfJS.graph.directed ? strLang("inLinks") : strLang("undirLinks") ) + '</h4><ul>';
+	_str += '</ul>';
+	var _str_in = "",
+	    _str_out = "",
+	    _str_undir = "";
         for (var i in GexfJS.graph.edgeList) {
             var _e = GexfJS.graph.edgeList[i];
             if ( _e.target == _nodeIndex ) {
                 var _n = GexfJS.graph.nodeList[_e.source];
-                _str += '<li><div class="smallpill" style="background: ' + _n.color.base +'"></div><a href="#" onmouseover="GexfJS.params.activeNode = ' + _e.source + '" onclick="displayNode(' + _e.source + ', true); return false;">' + _n.label + '</a>' + ( GexfJS.params.showEdgeLabel && _e.label ? ' &ndash; ' + _e.label : '') + ( GexfJS.params.showEdgeWeight && _e.weight ? ' [' + _e.weight + ']' : '') + '</li>';
+                tmp = '<li><div class="smallpill" style="background: ' + _n.color.base +'"></div><a href="#" onmouseover="GexfJS.params.activeNode = ' + _e.source + '" onclick="displayNode(' + _e.source + ', true); return false;">' + _n.label + '</a>' + ( GexfJS.params.showEdgeLabel && _e.label ? ' &ndash; ' + _e.label : '') + ( GexfJS.params.showEdgeWeight && _e.weight ? ' [' + _e.weight + ']' : '') + '</li>';
+		if ( _e.directed ) {
+		    _str_in += tmp
+		} else {
+		    _str_undir += tmp
+		}
             }
-        }
-        if (GexfJS.graph.directed) _str += '</ul><h4>' + strLang("outLinks") + '</h4><ul>';
-        for (var i in GexfJS.graph.edgeList) {
-            var _e = GexfJS.graph.edgeList[i];
-            if ( _e.source == _nodeIndex ) {
+	    if ( _e.source == _nodeIndex ) {
                 var _n = GexfJS.graph.nodeList[_e.target];
-                _str += '<li><div class="smallpill" style="background: ' + _n.color.base +'"></div><a href="#" onmouseover="GexfJS.params.activeNode = ' + _e.target + '" onclick="displayNode(' + _e.target + ', true); return false;">' + _n.label + '</a>' + ( GexfJS.params.showEdgeLabel && _e.label ? ' &ndash; ' + _e.label : '') + ( GexfJS.params.showEdgeWeight && _e.weight ? ' [' + _e.weight + ']' : '') + '</li>';
+                tmp = '<li><div class="smallpill" style="background: ' + _n.color.base +'"></div><a href="#" onmouseover="GexfJS.params.activeNode = ' + _e.target + '" onclick="displayNode(' + _e.target + ', true); return false;">' + _n.label + '</a>' + ( GexfJS.params.showEdgeLabel && _e.label ? ' &ndash; ' + _e.label : '') + ( GexfJS.params.showEdgeWeight && _e.weight ? ' [' + _e.weight + ']' : '') + '</li>';
+		if ( _e.directed ) {
+		    _str_out += tmp
+		} else {
+		    _str_undir += tmp
+		}
             }
         }
-        _str += '</ul><p></p>';
+	if ( _str_in != "" ) {
+	    _str += '<h4>' + strLang("inLinks") + '</h4><ul>' + _str_in + '</ul>'
+	}
+	if ( _str_out != "" ) {
+	    _str += '<h4>' + strLang("outLinks") + '</h4><ul>' + _str_out + '</ul>'
+	}
+	if ( _str_undir != "" ) {
+	    _str += '<h4>' + strLang("undirLinks") + '</h4><ul>' + _str_undir + '</ul>'
+	}
+        _str += '<p></p>';
         $("#leftcontent").html(_str);
         if (_recentre) {
             GexfJS.params.centreX = _b.x;
@@ -494,7 +512,10 @@ function loadGraph() {
                     _tid = _e.attr("target"),
                     _tix = GexfJS.graph.nodeIndexById.indexOf(_tid);
                     _w = _e.find('attvalue[for="weight"]').attr('value') || _e.attr('weight');
-                    _col = _e.find("viz\\:color,color");
+                    _col = _e.find("viz\\:color,color"),
+		    _directed = GexfJS.graph.directed;
+		if (_e.attr("type") == "directed") _directed = true;
+		if (_e.attr("type") == "undirected") _directed = false;
                 if (_col.length) {
                     var _r = _col.attr("r"),
                         _g = _col.attr("g"),
@@ -519,6 +540,7 @@ function loadGraph() {
                     weight : parseFloat(_w || 0),
                     color : "rgba(" + _r + "," + _g + "," + _b + ",.7)",
                     label: _e.attr("label") || "",
+		    directed: _directed
                 });
             });
             

--- a/js/gexfjs.js
+++ b/js/gexfjs.js
@@ -596,24 +596,28 @@ function findAngle(sx, sy, ex, ey) {
 }
 
 function drawArrowhead(contexte, locx, locy, angle, sizex, sizey) {
+    tmp = contexte.lineWidth;
     var hx = sizex / 2;
     var hy = sizey / 2;
     contexte.translate((locx ), (locy));
     contexte.rotate(angle);
     contexte.translate(-hx,-hy);
+    contexte.lineWidth = 1;
     contexte.beginPath();
     contexte.moveTo(0,0);
     contexte.lineTo(0,1*sizey);    
     contexte.lineTo(1*sizex,1*hy);
     contexte.closePath();
+    contexte.fillStyle = "#424242";
     contexte.fill();
+    contexte.stroke();
     contexte.translate(hx,hy);
     contexte.rotate(-angle);
     contexte.translate(-locx, -locy);
+    contexte.lineWidth = tmp;
 }
 
-function traceArc(contexte, source, target, draw_arrow) {
-    var arrow_size = 22;
+function traceArc(contexte, source, target, arrow_size, draw_arrow) {
     contexte.beginPath();
     contexte.moveTo(source.x, source.y);
     if (GexfJS.params.curvedEdges) {
@@ -646,8 +650,7 @@ function traceArc(contexte, source, target, draw_arrow) {
 	    var tmp = Math.pow(0.5,2)
 	    var x_prime_middle = 3*tmp*(- x2 - x3 + x4 + x5)
 	    var y_prime_middle = 3*tmp*(- y2 - y3 + y4 + y5)
-	    drawArrowhead(contexte,x_middle,y_middle, findAngle(0,0,x_prime_middle, y_prime_middle), GexfJS.overviewScale*arrow_size, GexfJS.overviewScale*arrow_size);
-	    contexte.stroke();
+	    drawArrowhead(contexte,x_middle,y_middle, findAngle(0,0,x_prime_middle, y_prime_middle), arrow_size, arrow_size);
 	}
     } else {
         contexte.lineTo(target.x,target.y);
@@ -744,7 +747,7 @@ function traceMap() {
             var _coords = ( ( GexfJS.params.useLens && GexfJS.mousePosition ) ? calcCoord( GexfJS.mousePosition.x , GexfJS.mousePosition.y , _ds.coords.actual ) : _ds.coords.actual );
             _coordt = ( (GexfJS.params.useLens && GexfJS.mousePosition) ? calcCoord( GexfJS.mousePosition.x , GexfJS.mousePosition.y , _dt.coords.actual ) : _dt.coords.actual );
             GexfJS.ctxGraphe.strokeStyle = ( _isLinked ? _d.color : "rgba(100,100,100,0.2)" );
-            traceArc(GexfJS.ctxGraphe, _coords, _coordt, GexfJS.params.showEdgeArrow && _d.directed);
+            traceArc(GexfJS.ctxGraphe, _coords, _coordt, _sizeFactor * 5, GexfJS.params.showEdgeArrow && _d.directed);
         }
     }
     GexfJS.ctxGraphe.lineWidth = 4;

--- a/js/gexfjs.js
+++ b/js/gexfjs.js
@@ -747,7 +747,7 @@ function traceMap() {
             var _coords = ( ( GexfJS.params.useLens && GexfJS.mousePosition ) ? calcCoord( GexfJS.mousePosition.x , GexfJS.mousePosition.y , _ds.coords.actual ) : _ds.coords.actual );
             _coordt = ( (GexfJS.params.useLens && GexfJS.mousePosition) ? calcCoord( GexfJS.mousePosition.x , GexfJS.mousePosition.y , _dt.coords.actual ) : _dt.coords.actual );
             GexfJS.ctxGraphe.strokeStyle = ( _isLinked ? _d.color : "rgba(100,100,100,0.2)" );
-            traceArc(GexfJS.ctxGraphe, _coords, _coordt, _sizeFactor * 5, GexfJS.params.showEdgeArrow && _d.directed);
+            traceArc(GexfJS.ctxGraphe, _coords, _coordt, _sizeFactor * 3.5, GexfJS.params.showEdgeArrow && _d.directed);
         }
     }
     GexfJS.ctxGraphe.lineWidth = 4;

--- a/js/gexfjs.js
+++ b/js/gexfjs.js
@@ -220,7 +220,10 @@ function displayNode(_nodeIndex, _recentre) {
             });
         _str += '<h3><div class="largepill" style="background: ' + _d.color.base +'"></div>' + _d.label + '</h3>';
         _str += '<h4>' + strLang("nodeAttr") + '</h4>';
-        _str += '<ul><li><b>id</b> : ' + _d.id + '</li>';
+        _str += '<ul>';
+	if (GexfJS.params.showId) {
+	    _str += '<li><b>id</b> : ' + _d.id + '</li>';
+	}
         for (var i in _d.attributes) {
             _str += '<li><b>' + strLang(i) + '</b> : ' + replaceURLWithHyperlinks( _d.attributes[i] ) + '</li>';
         }


### PR DESCRIPTION
Hello,

I modified the code to provide an easy way to hide the Id in the config file, and also I add a support for hybrid directed graphs. As explained in the commit the default directed/undirected option is set with 

    defaultedgetype="undirected"

but you can put for each edge another option with something like 

    <edge id="381" source="263" target="21" type="directed">
      <attvalues>
        <attvalue for="Catégorie" value="Alliance"></attvalue>
      </attvalues>
    </edge>

I also added a way to add an arrow when the edge is directed. You can find a screenshot here: http://wstaw.org/m/2015/06/26/plasma-desktopg25366.png.