### PR TITLE
Touchscreen support and even better translation for Dutch

### DIFF
--- a/js/gexfjs.js
+++ b/js/gexfjs.js
@@ -464,7 +464,7 @@ function onGraphScroll(evt, delta) {
         if (GexfJS.totalScroll < 0) {
             if (GexfJS.params.zoomLevel > GexfJS.minZoom) {
                 GexfJS.params.zoomLevel--;
-                var _el = $('#carte'),
+                var _el = (typeof($(this).offset()) == 'object') ? $(this) : $('#carte'),
                     _off = _el.offset(),
                     _deltaX = evt.pageX - _el.width() / 2 - _off.left,
                     _deltaY = evt.pageY - _el.height() / 2 - _off.top;
@@ -476,7 +476,7 @@ function onGraphScroll(evt, delta) {
             if (GexfJS.params.zoomLevel < GexfJS.maxZoom) {
                 GexfJS.params.zoomLevel++;
                 GexfJS.echelleGenerale = Math.pow( Math.SQRT2, GexfJS.params.zoomLevel );
-                var _el = $('#carte'),
+                var _el = (typeof($(this).offset()) == 'object') ? $(this) : $('#carte'),
                     _off = _el.offset(),
                     _deltaX = evt.pageX - _el.width() / 2 - _off.left,
                     _deltaY = evt.pageY - _el.height() / 2 - _off.top;

--- a/js/gexfjs.js
+++ b/js/gexfjs.js
@@ -178,6 +178,22 @@ var GexfJS = {
             "zoomIn" : "Yaklaştır",
             "zoomOut" : "Uzaklaştır",
             "browserErr" : "Tarayıcınız sayfayı doğru bir biçimde görüntüleyemiyor.<br />En son Firefox veya Chrome sürümünü kullanmanızı tavsiye ederiz."
+        },
+        "nl" : {
+            "search" : "Knooppunten doorzoeken",
+            "nodeAttr" : "Attributen",
+            "nodes" : "Knooppunten",
+            "inLinks" : "Binnenkomende verbindingen van :",
+            "outLinks" : "Uitgaande verbindingen naar :",
+            "undirLinks" : "Ongerichtte verbindingen met:",
+            "lensOn" : "Loepmodus activeren",
+            "lensOff" : "Loepmodus deactiveren",
+            "edgeOn" : "Kanten tonen",
+            "edgeOff" : "Kanten verbergen",
+            "zoomIn" : "Inzoomen",
+            "zoomOut" : "Uitzoomen",
+            "browserErr" : 'Your browser cannot properly display this page.<br />We recommend you use the latest <a href="http://www.mozilla.com/" target="_blank">Firefox</a> or <a href="http://www.google.com/chrome/" target="_blank">Chrome</a> version'
+            "browserErr" : 'Uw browser kan deze pagina niet correct tonen.<br />We raden aan de meest recente versie van <a href="http://www.mozilla.com/" target="_blank">Firefox</a> of <a href="http://www.google.com/chrome/" target="_blank">Chrome</a> te gebruiken'
         }
     },
     lang : "en"


### PR DESCRIPTION
This version adds touch screen support. Users on touch screen devices can now drag over the chart and they can use pinch-to-zoom on the chart (not on the overview box as this will probably be too small to make a difference anyway).
In the previous versions, only the buttons could be used for zooming and dragging over the chart was impossible on touch screen devices (for instance, my Ipad).

Further more, I added a slightly Dutch translation that is slightly improved in comparison to the one previously sent in.